### PR TITLE
fix doc error in ch.19

### DIFF
--- a/book/19-ppu-modes.md
+++ b/book/19-ppu-modes.md
@@ -254,7 +254,7 @@ impl Cpu {
     pub fn tick(&mut self) -> bool {
         let cycles = if self.halted { 1 } else { opcodes::execute(self) };
         let ppu_result = self.bus.update_ppu(cycles);
-        return ppu_result == LcdResults::RenderFrame;
+        return ppu_result.lcd_result == LcdResults::RenderFrame;
     }
 }
 ```


### PR DESCRIPTION
Chapter 19 documents a comparison operation between a PpuUpdateResult struct and an LcdResults enum in the last code block of the chapter. I believe this should document a comparison operation on the lcd_result member field of the PpuUpdateResult struct.